### PR TITLE
Integrate travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+
+node_js:
+  - 'stable'
+  - '6'
+
+sudo: false
+
+before_script:
+  npm install
+
+script:
+  npm run compile
+  npm test
+
+cache:
+  directories:
+    - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ node_js:
 sudo: false
 
 before_script:
-  npm install
+  - npm install
 
 script:
-  npm run compile
-  npm test
+  - npm run compile
+  - npm test
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://gitlab.informagic.net/thandwerker/tslint-multamedio-rules.git"
+    "url": "https://github.com/ThomasHandwerker/tslint-multamedio-rules.git"
   },
   "keywords": [
     "linter",


### PR DESCRIPTION
Add .travis.yml file in order to use travis build-tool for automated compile and test tslint-custom-rules.